### PR TITLE
fix(sec): upgrade mysql:mysql-connector-java to 8.0.28

### DIFF
--- a/springboot-detect-faces/face-web/pom.xml
+++ b/springboot-detect-faces/face-web/pom.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.face</groupId>
@@ -39,7 +38,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.18</version>
+            <version>8.0.28</version>
         </dependency>
     </dependencies>
     <build>

--- a/springboot-seata-transaction/pom.xml
+++ b/springboot-seata-transaction/pom.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.notebook</groupId>
@@ -23,7 +22,7 @@
 
 	<properties>
 		<java.version>1.8</java.version>
-		<mysql-connector-java.version>5.1.37</mysql-connector-java.version>
+		<mysql-connector-java.version>8.0.28</mysql-connector-java.version>
 		<mybatis-spring-boot-starter.version>2.0.0</mybatis-spring-boot-starter.version>
 		<druid-spring-boot-starter.version>1.1.10</druid-spring-boot-starter.version>
 		<lombok.version>1.18.8</lombok.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in mysql:mysql-connector-java 8.0.23
- [CVE-2022-21363](https://www.oscs1024.com/hd/CVE-2022-21363)


### What did I do？
Upgrade mysql:mysql-connector-java from 8.0.23 to 8.0.28 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS