### PR TITLE
Could com.notebook:springboot-realtime-data:0.0.1-SNAPSHOT drop off redundant dependencies?

### DIFF
--- a/springboot-realtime-data/pom.xml
+++ b/springboot-realtime-data/pom.xml
@@ -20,6 +20,24 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>22.0</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>j2objc-annotations</artifactId>
+                    <groupId>com.google.j2objc</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>error_prone_annotations</artifactId>
+                    <groupId>com.google.errorprone</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>animal-sniffer-annotations</artifactId>
+                    <groupId>org.codehaus.mojo</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>jsr305</artifactId>
+                    <groupId>com.google.code.findbugs</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!--mqtt依赖包-->
         <dependency>
@@ -43,7 +61,12 @@
             <version>4.9.0</version>
             <scope>compile</scope>
         </dependency>
-
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.7</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/126549527/231443349-bfd7a894-ac84-43be-8717-4d8571879a7a.png)

Hi, I found that **_com.notebook:springboot-realtime-data:0.0.1-SNAPSHOT_**’s pom file introduced **_90_** dependencies. However, among them, **_5_** libraries (**_6%_** have not been used by your project), the redundant dependencies are listed below.

More seriously, **_5_**  redundant libraries have not been maintained by developers for more than **_3_** years (outdated dependencies).

Reduce these unused dependencies can help prevent introducing bugs/vulnerabilities from dependencies with outdated. Meanwhile, it can minimize the project size. To safely remove redundant dependencies, I constructed a complete call graph (resolved most of Java reflection and dynamic binding), and validated that they have not been used by the client code.

This PR **_com.notebook:springboot-realtime-data:0.0.1-SNAPSHOT_** for removing the redundant dependencies have passed the tests.

Best regards

## Redundant dependencies
#### Redundant indirect dependencies:
        com.google.errorprone:error_prone_annotations:2.0.18:compile [11 KB]
        com.google.j2objc:j2objc-annotations:1.1:compile [8 KB]
        org.codehaus.mojo:animal-sniffer-annotations:1.14:compile [3 KB]
        com.google.code.findbugs:jsr305:1.3.9:compile [32 KB]
#### Redundant direct dependencies inherited from parent pom:
        org.apache.commons:commons-lang3:3.7:compile [487 KB]

## Outdated dependencies
org.apache.commons:commons-lang3:3.7 (**_1984_** days without maintenance)
com.google.errorprone:error_prone_annotations:2.0.18 (**_2233_** days without maintenance)
org.codehaus.mojo:animal-sniffer-annotations:1.14 (**_2967_** days without maintenance)
com.google.j2objc:j2objc-annotations:1.1 (**_2274_** days without maintenance)
com.google.code.findbugs:jsr305:1.3.9 (**_4978_** days without maintenance)